### PR TITLE
use which instead of type to find exe in path

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
 		"through2": "^2.0.3"
 	},
 	"scripts": {
-		"postinstall": "type youtube-dl >/dev/null 2>&1 || {echo >&2 'youtube-dl must be installed. See youtube-dl.org.'}"
+		"postinstall": "which youtube-dl >/dev/null 2>&1 || {echo >&2 'youtube-dl must be installed. See youtube-dl.org.'}"
 	}
 }


### PR DESCRIPTION
The type command does not seem like the correct command to use in cmd.exe to see if an executable exists in the path. The which command does seem to work when I test with valid and invalid programs.